### PR TITLE
feat: support full verbatim configuration values

### DIFF
--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/VerbatimWrapper.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/VerbatimWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.config.pebble;
+
+/**
+ * Wrapper for String values to prevent evaluation.
+ *
+ * @author Simon Templer
+ */
+public class VerbatimWrapper {
+
+  private final String value;
+
+  public VerbatimWrapper(String value) {
+    super();
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return getValue();
+  }
+
+}


### PR DESCRIPTION
The goal is to avoid processing for the configuration value content
even when there are multiple evaluation passes.
Use case is being able to use Pebble templates as configuration values
and not try to evaluate the template as part of the configuration.