### PR TITLE
fix: escape additional characters for sed calls

### DIFF
--- a/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/DoubleQuotesEscaper.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/DoubleQuotesEscaper.java
@@ -30,7 +30,15 @@ public class DoubleQuotesEscaper implements EscapingStrategy {
 
   @Override
   public String escape(String input) {
-    return input.replaceAll(Pattern.quote("\""), Matcher.quoteReplacement("\\\""));
+    String res = input;
+    
+    res = res.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("\\\\\\\\"));
+    
+    res = res.replaceAll(Pattern.quote("\""), Matcher.quoteReplacement("\\\""));
+    res = res.replaceAll(Pattern.quote("$"), Matcher.quoteReplacement("\\$"));
+    res = res.replaceAll(Pattern.quote("&"), Matcher.quoteReplacement("\\&"));
+      
+    return res;
   }
 
 }


### PR DESCRIPTION
Adapted doublequotes escaper to escape additional characters. Renaming of the escaping strategy still has to be done.