### PR TITLE
feat: add ifNull filter that provides a default only for null values

### DIFF
--- a/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/IfNullFilter.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/IfNullFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.actions.assemble.template;
+
+import java.util.Map;
+
+import com.mitchellbosecke.pebble.error.AttributeNotFoundException;
+import com.mitchellbosecke.pebble.extension.core.DefaultFilter;
+
+/**
+ * Filter that returns a provided default value if the input is <code>null</code>.
+ * Extends {@link DefaultFilter} to prevent a possible {@link AttributeNotFoundException} to be thrown.
+ *
+ * @author Simon Templer
+ */
+public class IfNullFilter extends DefaultFilter {
+
+  @Override
+  public Object apply(Object input, Map<String, Object> args) {
+      Object defaultObj = args.get("default");
+
+      if (input == null) {
+          return defaultObj;
+      }
+      return input;
+  }
+
+}

--- a/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/SwarmComposerExtension.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/SwarmComposerExtension.java
@@ -41,6 +41,7 @@ public class SwarmComposerExtension extends AbstractExtension {
     filters.put("yaml", new YamlFilter());
     filters.put("json", new JsonFilter());
     filters.put("prettyJson", new PrettyJsonFilter());
+    filters.put("ifNull", new IfNullFilter());
 
     functions.put("generatePassword", new GeneratePasswordFunction());
 


### PR DESCRIPTION
This allows using an empty value in case a variable is defined with an
empty value. The default value will only be used here if the variable is
not defined or its value is null.