### PR TITLE
refactor: improved evaluation of configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 group = 'to.wetransform'
-version = '0.4.0-SNAPSHOT'
+version = '0.5.0-SNAPSHOT'
 
 repositories {
   jcenter()

--- a/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerExtension.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerExtension.groovy
@@ -61,6 +61,14 @@ class SwarmComposerExtension {
   }
 
   /**
+   * Adapt a setup configuration after it was initialized.
+   * Called with the respective SetupConfiguration object as delegate.
+   */
+  void configureSetup(Closure cl) {
+    configureClosures << cl.clone()
+  }
+
+  /**
    * Template engine, defaults to Pebble.
    */
   TemplateAssembler templateEngine = new PebbleAssembler()
@@ -93,12 +101,14 @@ class SwarmComposerExtension {
 
   // advanced users
 
-  final SetupConfigurations configs = new SetupConfigurations()
+  final SetupConfigurations configs = new SetupConfigurations(this)
 
   // internal
 
   final Project project
 
   Closure dockerConfig
+
+  final List<Closure> configureClosures = []
 
 }

--- a/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerExtension.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerExtension.groovy
@@ -45,6 +45,13 @@ class SwarmComposerExtension {
   boolean enableBuilds = true
 
   /**
+   * If tasks for exporting configurations are enabled.
+   * Mainly intended for debugging.
+   * Create files in folder of respective stack that likely contains secrets.
+   */
+  boolean enableConfigExport = false
+
+  /**
    * Enables checking if Docker is connected to the right swarm for
    * a specific setup by checking the node label <code>sc-setup</code>.
    *

--- a/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerPlugin.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerPlugin.groovy
@@ -613,7 +613,9 @@ $run"""
           // main config
           config,
           // allow extending root map
-          true
+          true,
+          // don't make local available in addition on special key
+          false
           )
 
         // check if build is enabled

--- a/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/LazyContextWrapper.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/LazyContextWrapper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.actions.assemble.template;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Wraps a map and returns {@link ContextWrapper}s for all children of type map.
+ *
+ * Is used to avoid evaluating all expressions in a {@link PebbleCachingEvaluator}
+ *
+ * @author Simon Templer
+ */
+public class LazyContextWrapper implements Map<String, Object> {
+
+  private final Map<String, Object> decoratee;
+
+  public LazyContextWrapper(Map<String, Object> decoratee) {
+    super();
+    this.decoratee = decoratee;
+  }
+
+  @Override
+  public int size() {
+    return decoratee.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return decoratee.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return decoratee.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    if (value instanceof ContextWrapper) {
+      value = ((ContextWrapper) value).getInternalMap();
+    }
+
+    return decoratee.containsValue(value);
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Object get(Object key) {
+    Object value = decoratee.get(key);
+    if (value instanceof Map) {
+      value = new ContextWrapper(key.toString(), (Map) value);
+    }
+    return value;
+  }
+
+  @Override
+  public Object put(String key, Object value) {
+    return decoratee.put(key, value);
+  }
+
+  @Override
+  public Object remove(Object key) {
+    return decoratee.remove(key);
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ? extends Object> m) {
+    decoratee.putAll(m);
+  }
+
+  @Override
+  public void clear() {
+    decoratee.clear();
+  }
+
+  @Override
+  public Set<String> keySet() {
+    return decoratee.keySet();
+  }
+
+  @Override
+  public Collection<Object> values() {
+    return entrySet().stream().map(e -> e.getValue()).collect(Collectors.toList());
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<java.util.Map.Entry<String, Object>> entrySet() {
+    return decoratee.entrySet().stream().map(entry -> {
+      Object value = entry.getValue();
+      if (value instanceof Map) {
+        value = new ContextWrapper(entry.getKey(), (Map) value);
+      }
+      return new AbstractMap.SimpleEntry<String, Object>(entry.getKey(), value);
+    }).collect(Collectors.toSet());
+  }
+
+}

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/ConfigHelper.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/ConfigHelper.groovy
@@ -21,9 +21,8 @@ import java.nio.charset.StandardCharsets
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.SafeConstructor
-
-import to.wetransform.gradle.swarm.config.pebble.PebbleEvaluator
-import to.wetransform.gradle.swarm.util.Helpers;;
+import to.wetransform.gradle.swarm.config.pebble.PebbleCachingEvaluator
+import to.wetransform.gradle.swarm.util.Helpers
 
 /**
  * Helpers for configurations based on maps and lists.
@@ -81,7 +80,7 @@ class ConfigHelper {
 
     // evaluate configuration
     if (evaluate) {
-      ConfigEvaluator evaluator = new PebbleEvaluator()
+      ConfigEvaluator evaluator = new PebbleCachingEvaluator()
       context = evaluator.evaluate(context)
     }
 

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/SetupConfiguration.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/SetupConfiguration.groovy
@@ -65,6 +65,7 @@ class SetupConfiguration {
    */
   void addConfig(Map conf) {
     config = ConfigHelper.mergeConfigs([config ?: [:], conf])
+    unevaluated = ConfigHelper.mergeConfigs([unevaluated ?: [:], conf])
   }
 
   /**

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/AbstractPebbleEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/AbstractPebbleEvaluator.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.config.pebble
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory;
+
+import com.mitchellbosecke.pebble.PebbleEngine
+import com.mitchellbosecke.pebble.lexer.LexerImpl;
+import com.mitchellbosecke.pebble.lexer.TokenStream;
+import com.mitchellbosecke.pebble.loader.StringLoader
+import com.mitchellbosecke.pebble.node.RootNode;
+import com.mitchellbosecke.pebble.parser.Parser;
+import com.mitchellbosecke.pebble.parser.ParserImpl
+import com.mitchellbosecke.pebble.template.PebbleTemplate
+
+import to.wetransform.gradle.swarm.actions.assemble.template.ContextWrapper;
+import to.wetransform.gradle.swarm.actions.assemble.template.SwarmComposerExtension
+import to.wetransform.gradle.swarm.config.ConfigEvaluator
+import to.wetransform.gradle.swarm.config.ConfigHelper
+
+/**
+ * Evaluates config based on Pebble templates.
+ *
+ * @author Simon Templer
+ */
+abstract class AbstractPebbleEvaluator implements ConfigEvaluator {
+
+  protected final PebbleEngine engine
+
+  private static final Logger log = LoggerFactory.getLogger(AbstractPebbleEvaluator)
+
+  protected final boolean lenient
+
+  AbstractPebbleEvaluator() {
+    this(false)
+  }
+
+  AbstractPebbleEvaluator(boolean lenient) {
+    super()
+    this.lenient = lenient
+
+    engine = new PebbleEngine.Builder()
+    .newLineTrimming(true)
+    .strictVariables(!lenient)
+    .autoEscaping(false)
+    .extension(new SwarmComposerExtension())
+    .loader(new StringLoader())
+    .build()
+  }
+
+  boolean isDynamicValue(String value) {
+    //XXX this function uses Pebble internal API
+
+    try {
+      LexerImpl lexer = new LexerImpl(engine.syntax, engine.extensionRegistry.getUnaryOperators().values(),
+        engine.extensionRegistry.getBinaryOperators().values())
+      Reader templateReader = new StringReader(value)
+      TokenStream tokenStream = lexer.tokenize(templateReader, 'dynamic')
+
+      Parser parser = new ParserImpl(engine.extensionRegistry.getUnaryOperators(),
+        engine.extensionRegistry.getBinaryOperators(), engine.extensionRegistry.getTokenParsers());
+      RootNode root = parser.parse(tokenStream)
+      def visitor = new DynamicCheckVisitor()
+      root.accept(visitor)
+      visitor.dynamic
+    } catch (e) {
+      log.warn("Could not determine if expression is dynamic: $value", e)
+      false
+    }
+  }
+
+  Collection<List<String>> getDependencies(String value) {
+    //XXX this function uses Pebble internal API
+
+    try {
+      LexerImpl lexer = new LexerImpl(engine.syntax, engine.extensionRegistry.getUnaryOperators().values(),
+        engine.extensionRegistry.getBinaryOperators().values())
+      Reader templateReader = new StringReader(value)
+      TokenStream tokenStream = lexer.tokenize(templateReader, 'dynamic')
+
+      Parser parser = new ParserImpl(engine.extensionRegistry.getUnaryOperators(),
+        engine.extensionRegistry.getBinaryOperators(), engine.extensionRegistry.getTokenParsers());
+      RootNode root = parser.parse(tokenStream)
+      def visitor = new DependencyCollectorVisitor()
+      root.accept(visitor)
+      visitor.dependencies
+    } catch (e) {
+      log.warn("Could not determine if expression is dynamic: $value", e)
+      false
+    }
+  }
+
+}

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/DependencyCollectorVisitor.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/DependencyCollectorVisitor.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2017 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.config.pebble;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.mitchellbosecke.pebble.extension.NodeVisitor;
+import com.mitchellbosecke.pebble.node.ArgumentsNode;
+import com.mitchellbosecke.pebble.node.AutoEscapeNode;
+import com.mitchellbosecke.pebble.node.BlockNode;
+import com.mitchellbosecke.pebble.node.BodyNode;
+import com.mitchellbosecke.pebble.node.ExtendsNode;
+import com.mitchellbosecke.pebble.node.FlushNode;
+import com.mitchellbosecke.pebble.node.ForNode;
+import com.mitchellbosecke.pebble.node.IfNode;
+import com.mitchellbosecke.pebble.node.ImportNode;
+import com.mitchellbosecke.pebble.node.IncludeNode;
+import com.mitchellbosecke.pebble.node.MacroNode;
+import com.mitchellbosecke.pebble.node.NamedArgumentNode;
+import com.mitchellbosecke.pebble.node.Node;
+import com.mitchellbosecke.pebble.node.ParallelNode;
+import com.mitchellbosecke.pebble.node.PositionalArgumentNode;
+import com.mitchellbosecke.pebble.node.PrintNode;
+import com.mitchellbosecke.pebble.node.RootNode;
+import com.mitchellbosecke.pebble.node.SetNode;
+import com.mitchellbosecke.pebble.node.TextNode;
+import com.mitchellbosecke.pebble.node.expression.BinaryExpression;
+import com.mitchellbosecke.pebble.node.expression.ContextVariableExpression;
+import com.mitchellbosecke.pebble.node.expression.Expression;
+import com.mitchellbosecke.pebble.node.expression.FunctionOrMacroInvocationExpression;
+import com.mitchellbosecke.pebble.node.expression.GetAttributeExpression;
+import com.mitchellbosecke.pebble.node.expression.LiteralStringExpression;
+import com.mitchellbosecke.pebble.node.expression.UnaryExpression;
+
+/**
+ * Visitor that checks if there is any dynamic content in the visited nodes.
+ *
+ * @author Simon Templer
+ */
+public class DependencyCollectorVisitor implements NodeVisitor {
+
+  private Set<List<String>> dependencies = new HashSet<>();
+
+  public Set<List<String>> getDependencies() {
+    return Collections.unmodifiableSet(dependencies);
+  }
+
+  protected void analyzeExpression(Expression<?> expression) {
+    List<String> dep = doAnalyzeExpression(expression, true);
+    if (dep != null) {
+      dependencies.add(Collections.unmodifiableList(dep));
+    }
+  }
+
+  protected List<String> doAnalyzeExpression(Expression<?> expression, boolean root) {
+    while (expression instanceof UnaryExpression) {
+      expression = ((UnaryExpression) expression).getChildExpression();
+    }
+
+    if (expression instanceof FunctionOrMacroInvocationExpression) {
+      visit(((FunctionOrMacroInvocationExpression) expression).getArguments());
+      return null;
+    }
+    else if (expression instanceof BinaryExpression<?>) {
+      BinaryExpression<?> expr = (BinaryExpression<?>) expression;
+
+      // analyze each
+      analyzeExpression(expr.getLeftExpression());
+      analyzeExpression(expr.getRightExpression());
+
+      return null;
+    }
+    else if (expression instanceof ContextVariableExpression) {
+      ContextVariableExpression expr = (ContextVariableExpression) expression;
+
+      if (root) {
+        return Collections.singletonList(expr.getName());
+      }
+      else {
+        // this is always the beginning of a reference
+        analyzeExpression(expr);
+
+        return null;
+      }
+    }
+    else if (expression instanceof GetAttributeExpression) {
+      GetAttributeExpression expr = (GetAttributeExpression) expression;
+
+      List<String> head = doAnalyzeExpression(expr.getNode(), root);
+      if (head != null) {
+        List<String> tail = doAnalyzeExpression(expr.getAttributeNameExpression(), false);
+        if (tail != null) {
+          head = new ArrayList<>(head);
+          head.addAll(tail);
+        }
+        return head;
+      }
+    }
+    else if (expression instanceof LiteralStringExpression && !root) {
+      LiteralStringExpression expr = (LiteralStringExpression) expression;
+
+      return Collections.singletonList(expr.getValue());
+    }
+
+    return null;
+  }
+
+  @Override
+  public void visit(Node node) {
+    // ignore
+    //XXX for which nodes is this called?
+  }
+
+  @Override
+  public void visit(ArgumentsNode node) {
+    List<NamedArgumentNode> namedArgs = node.getNamedArgs();
+    if (namedArgs != null) {
+      namedArgs.forEach((n) -> n.accept(this));
+    }
+
+    List<PositionalArgumentNode> posArgs = node.getPositionalArgs();
+    if (posArgs != null) {
+      posArgs.forEach((n) -> n.accept(this));
+    }
+  }
+
+  @Override
+  public void visit(AutoEscapeNode node) {
+    node.getBody().accept(this);
+  }
+
+  @Override
+  public void visit(BlockNode node) {
+    node.getBody().accept(this);
+  }
+
+  @Override
+  public void visit(BodyNode node) {
+    node.getChildren().forEach((n) -> n.accept(this));
+  }
+
+  @Override
+  public void visit(ExtendsNode node) {
+    analyzeExpression(node.getParentExpression());
+  }
+
+  @Override
+  public void visit(FlushNode node) {
+    // ignore
+  }
+
+  @Override
+  public void visit(ForNode node) {
+    Expression<?> iterable = node.getIterable();
+    analyzeExpression(iterable);
+
+    BodyNode forBody = node.getBody();
+    if (forBody != null) {
+      forBody.accept(this);
+    }
+
+    BodyNode elseBody = node.getElseBody();
+    if (elseBody != null) {
+      elseBody.accept(this);
+    }
+  }
+
+  @Override
+  public void visit(IfNode node) {
+    node.getConditionsWithBodies().forEach((pair) -> {
+      Expression<?> condition = pair.getLeft();
+      analyzeExpression(condition);
+      BodyNode then = pair.getRight();
+      then.accept(this);
+    });
+
+    BodyNode elseBody = node.getElseBody();
+    if (elseBody != null) {
+      elseBody.accept(this);
+    }
+  }
+
+  @Override
+  public void visit(ImportNode node) {
+    // ignore
+  }
+
+  @Override
+  public void visit(IncludeNode node) {
+ // ignore - not supported in config?
+  }
+
+  @Override
+  public void visit(MacroNode node) {
+    // ignore - not supported in config?
+  }
+
+  @Override
+  public void visit(NamedArgumentNode node) {
+    analyzeExpression(node.getValueExpression());
+  }
+
+  @Override
+  public void visit(ParallelNode node) {
+    // ignore - not supported in config?
+  }
+
+  @Override
+  public void visit(PositionalArgumentNode node) {
+    analyzeExpression(node.getValueExpression());
+  }
+
+  @Override
+  public void visit(PrintNode node) {
+    analyzeExpression(node.getExpression());
+  }
+
+  @Override
+  public void visit(RootNode node) {
+    node.getBody().accept(this);
+  }
+
+  @Override
+  public void visit(SetNode node) {
+    analyzeExpression(node.getValue());
+  }
+
+  @Override
+  public void visit(TextNode node) {
+    // not dynamic
+  }
+
+}

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
@@ -106,7 +106,7 @@ class PebbleCachingEvaluator extends AbstractPebbleEvaluator {
       }
       else {
         // this is local
-        context = new RootOrLocalMap(root, this, false)
+        context = new RootOrLocalMap(root, this, false, true)
       }
 
       PebbleTemplate compiledTemplate = PebbleCachingEvaluator.this.engine.getTemplate(value);

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
@@ -74,6 +74,10 @@ class PebbleCachingEvaluator extends AbstractPebbleEvaluator {
     private Object evaluate(Object key) {
       def value = original.get(key)
 
+      return evaluateObject(value)
+    }
+
+    private def evaluateObject(Object value) {
       if (value == null) {
         return null
       }
@@ -81,8 +85,9 @@ class PebbleCachingEvaluator extends AbstractPebbleEvaluator {
         return new PebbleCachingConfig(value, root ?: this)
       }
       else if (value instanceof List) {
-        //FIXME currently not supported
-        return value
+        return value.collect { Object obj ->
+          this.evaluateObject(obj)
+        }.toList()
       }
       else if (value instanceof String || value instanceof GString) {
         return evaluateValue(value as String)

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2017 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.config.pebble
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleEntry
+import java.util.Collection
+import java.util.Map
+import java.util.Set
+import java.util.function.Function
+import java.util.stream.Collectors
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory;
+
+import com.mitchellbosecke.pebble.PebbleEngine
+import com.mitchellbosecke.pebble.lexer.LexerImpl;
+import com.mitchellbosecke.pebble.lexer.TokenStream;
+import com.mitchellbosecke.pebble.loader.StringLoader
+import com.mitchellbosecke.pebble.node.RootNode;
+import com.mitchellbosecke.pebble.parser.Parser;
+import com.mitchellbosecke.pebble.parser.ParserImpl
+import com.mitchellbosecke.pebble.template.PebbleTemplate
+
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
+import to.wetransform.gradle.swarm.actions.assemble.template.ContextWrapper;
+import to.wetransform.gradle.swarm.actions.assemble.template.LazyContextWrapper
+import to.wetransform.gradle.swarm.actions.assemble.template.SwarmComposerExtension
+import to.wetransform.gradle.swarm.config.ConfigEvaluator
+import to.wetransform.gradle.swarm.config.ConfigHelper
+
+/**
+ * Evaluates configuration based on Pebble templates.
+ * Map entries are evaluated lazily if possible and the result is cached.
+ *
+ * @author Simon Templer
+ */
+@CompileStatic
+class PebbleCachingEvaluator extends AbstractPebbleEvaluator {
+
+  class PebbleCachingConfig implements Map<String, Object> {
+
+    private final Map<String, Object> original
+
+    private final Map<String, Object> evaluated
+
+    private final PebbleCachingConfig root
+
+    PebbleCachingConfig(Map<String, Object> original, PebbleCachingConfig root) {
+      this.original = original
+      this.evaluated = new HashMap<>()
+      this.root = root
+    }
+
+    private Object evaluate(Object key) {
+      def value = original.get(key)
+
+      if (value == null) {
+        return null
+      }
+      else if (value instanceof Map) {
+        return new PebbleCachingConfig(value, root ?: this)
+      }
+      else if (value instanceof List) {
+        //FIXME currently not supported
+        return value
+      }
+      else if (value instanceof String || value instanceof GString) {
+        return evaluateValue(value as String)
+      }
+      else {
+        // leave as-is
+        return value
+      }
+    }
+
+    private def evaluateValue(String value) {
+      Map context
+      if (root == null) {
+        // this is root
+        context = this
+      }
+      else {
+        // this is local
+        context = new RootOrLocalMap(root, this, false)
+      }
+
+      PebbleTemplate compiledTemplate = PebbleCachingEvaluator.this.engine.getTemplate(value);
+      StringWriter writer = new StringWriter()
+      if (lenient) {
+        compiledTemplate.evaluate(writer, context)
+      }
+      else {
+        compiledTemplate.evaluate(writer, new LazyContextWrapper(context))
+      }
+      def result = writer.toString()
+
+      // "hack" to convert to a boolean (for conditions)
+      if ('true' == result) {
+        true
+      }
+      else if('false' == result) {
+        false
+      }
+      else {
+        result
+      }
+    }
+
+    @Override
+    public int size() {
+      return original.size()
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return original.isEmpty()
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return original.containsKey(key)
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+      throw new UnsupportedOperationException('Not implemented')
+    }
+
+    @CompileStatic(TypeCheckingMode.SKIP)
+    @Override
+    public Object get(Object key) {
+      return evaluated.computeIfAbsent(key, this.&evaluate)
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+      throw new UnsupportedOperationException('Not implemented')
+    }
+
+    @Override
+    public Object remove(Object key) {
+      throw new UnsupportedOperationException('Not implemented')
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends Object> m) {
+      throw new UnsupportedOperationException('Not implemented')
+    }
+
+    @Override
+    public void clear() {
+      throw new UnsupportedOperationException('Not implemented')
+    }
+
+    @Override
+    public Set<String> keySet() {
+      return original.keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+      // Note: This method results in evaluation of all entries (via entrySet)
+
+      return entrySet().collect{ it.value }
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<String, Object>> entrySet() {
+      // Note: This method results in evaluation of all entries
+
+      Set<java.util.Map.Entry<String, Object>> result = new HashSet()
+
+      for (String key : keySet()) {
+        Object value = this.get(key)
+        if (value != null) {
+          result.add(new SimpleEntry(key, value))
+        }
+      }
+
+      return result
+    }
+
+  }
+
+  PebbleCachingEvaluator() {
+    super()
+  }
+
+  PebbleCachingEvaluator(boolean lenient) {
+    super(lenient)
+  }
+
+  @Override
+  public Map<String, Object> evaluate(Map<String, Object> config) {
+    return new PebbleCachingConfig(config, null)
+  }
+
+}

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
@@ -66,6 +66,8 @@ class PebbleCachingEvaluator extends AbstractPebbleEvaluator {
     private final PebbleCachingConfig root
 
     PebbleCachingConfig(Map<String, Object> original, PebbleCachingConfig root) {
+      if (original instanceof PebbleCachingConfig) throw new IllegalStateException('Cannot wrap a PebbleCachingConfig (would result in multiple evaluations)')
+
       this.original = original
       this.evaluated = new HashMap<>()
       this.root = root
@@ -80,6 +82,10 @@ class PebbleCachingEvaluator extends AbstractPebbleEvaluator {
     private def evaluateObject(Object value) {
       if (value == null) {
         return null
+      }
+      else if (value instanceof PebbleCachingConfig) {
+        // prevent double evaluation
+        return value
       }
       else if (value instanceof Map) {
         return new PebbleCachingConfig(value, root ?: this)

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleEvaluator.groovy
@@ -44,30 +44,20 @@ import to.wetransform.gradle.swarm.config.ConfigHelper
  * Evaluates config based on Pebble templates.
  *
  * @author Simon Templer
+ *
+ * @deprecated Use PebbleCachingEvaluator instead.
  */
-class PebbleEvaluator implements ConfigEvaluator {
-
-  private final PebbleEngine engine
+@Deprecated
+class PebbleEvaluator extends AbstractPebbleEvaluator {
 
   private static final Logger log = LoggerFactory.getLogger(PebbleEvaluator)
 
-  private final boolean lenient
-
   PebbleEvaluator() {
-    this(false)
+    super()
   }
 
   PebbleEvaluator(boolean lenient) {
-    super()
-    this.lenient = lenient
-
-    engine = new PebbleEngine.Builder()
-    .newLineTrimming(true)
-    .strictVariables(!lenient)
-    .autoEscaping(false)
-    .extension(new SwarmComposerExtension())
-    .loader(new StringLoader())
-    .build()
+    super(lenient)
   }
 
   @Override
@@ -184,27 +174,6 @@ class PebbleEvaluator implements ConfigEvaluator {
     }
     else {
       result
-    }
-  }
-
-  boolean isDynamicValue(String value) {
-    //XXX this function uses Pebble internal API
-
-    try {
-      LexerImpl lexer = new LexerImpl(engine.syntax, engine.extensionRegistry.getUnaryOperators().values(),
-        engine.extensionRegistry.getBinaryOperators().values())
-      Reader templateReader = new StringReader(value)
-      TokenStream tokenStream = lexer.tokenize(templateReader, 'dynamic')
-
-      Parser parser = new ParserImpl(engine.extensionRegistry.getUnaryOperators(),
-        engine.extensionRegistry.getBinaryOperators(), engine.extensionRegistry.getTokenParsers());
-      RootNode root = parser.parse(tokenStream)
-      def visitor = new DynamicCheckVisitor()
-      root.accept(visitor)
-      visitor.dynamic
-    } catch (e) {
-      log.warn("Could not determine if expression is dynamic: $value", e)
-      false
     }
   }
 

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/RootOrLocalMap.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/RootOrLocalMap.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.config.pebble;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Map that delegates to two maps, a root one and a local one, where the later one is
+ * intended for local/relative resolving. Resolving via root takes precedence over
+ * resolving via the local map.
+ *
+ * @author Simon Templer
+ */
+public class RootOrLocalMap implements Map<String, Object> {
+
+  private final Map<String, Object> root;
+  private final Map<String, Object> local;
+
+  private final boolean allowPut;
+
+  public RootOrLocalMap(Map<String, Object> root, Map<String, Object> local, boolean allowPut) {
+    super();
+
+    Preconditions.checkNotNull(root);
+    Preconditions.checkNotNull(local);
+
+    this.root = root;
+    this.local = local;
+    this.allowPut = allowPut;
+  }
+
+  @Override
+  public int size() {
+    return keySet().size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return root.isEmpty() && local.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return root.containsKey(key) ||  local.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return root.containsValue(value) || local.containsValue(value);
+  }
+
+  @Override
+  public Object get(Object key) {
+    if (root.containsKey(key)) {
+      return root.get(key);
+    }
+    return local.get(key); //FIXME fail if key not contained?
+  }
+
+  @Override
+  public Object put(String key, Object value) {
+    if (allowPut) {
+      return root.put(key, value);
+    }
+
+    throw new UnsupportedOperationException("Adding element to map not supported (Key " + key + ")");
+  }
+
+  @Override
+  public Object remove(Object key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void putAll(Map<? extends String, ? extends Object> m) {
+    if (allowPut) {
+      for (java.util.Map.Entry<? extends String, ? extends Object> entry : m.entrySet()) {
+        root.put(entry.getKey(), entry.getValue());
+      }
+    }
+    else throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<String> keySet() {
+    Set<String> keys = new HashSet<>(root.keySet());
+    keys.addAll(local.keySet());
+    return Collections.unmodifiableSet(keys);
+  }
+
+  @Override
+  public Collection<Object> values() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Set<java.util.Map.Entry<String, Object>> entrySet() {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/RootOrLocalMap.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/RootOrLocalMap.java
@@ -33,12 +33,15 @@ import com.google.common.base.Preconditions;
  */
 public class RootOrLocalMap implements Map<String, Object> {
 
+  public static final String LOCAL_ACCESS_KEY = "_";
+
   private final Map<String, Object> root;
   private final Map<String, Object> local;
 
   private final boolean allowPut;
+  private final boolean localAccess;
 
-  public RootOrLocalMap(Map<String, Object> root, Map<String, Object> local, boolean allowPut) {
+  public RootOrLocalMap(Map<String, Object> root, Map<String, Object> local, boolean allowPut, boolean localAccess) {
     super();
 
     Preconditions.checkNotNull(root);
@@ -47,6 +50,7 @@ public class RootOrLocalMap implements Map<String, Object> {
     this.root = root;
     this.local = local;
     this.allowPut = allowPut;
+    this.localAccess = localAccess;
   }
 
   @Override
@@ -71,6 +75,10 @@ public class RootOrLocalMap implements Map<String, Object> {
 
   @Override
   public Object get(Object key) {
+    if (localAccess && LOCAL_ACCESS_KEY.equals(key) && !root.containsKey(LOCAL_ACCESS_KEY) && !local.containsKey(LOCAL_ACCESS_KEY)) {
+      return local;
+    }
+
     if (root.containsKey(key)) {
       return root.get(key);
     }

--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
@@ -52,6 +52,82 @@ abstract class ConfigEvaluatorTest<T extends ConfigEvaluator> {
   }
 
   @Test
+  void testEvalVerbatim() {
+    def config = [
+      autofillRule: '{% verbatim %}{{dataset.name}}{% endverbatim %}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      autofillRule: '{{dataset.name}}'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testEvalVerbatim2() {
+    def config = [
+      autofillRule: '{% verbatim %}{{dataset.name}}{% endverbatim %}',
+      otherRule: '{{ autofillRule }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      autofillRule: '{{dataset.name}}',
+      otherRule: '{{dataset.name}}'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testEvalVerbatimFilter() {
+    def config = [
+      config: [
+        autofillRule: '{% verbatim %}{{dataset.name}}{% endverbatim %}',
+      ],
+      json: '{{ config | json }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      config: [
+        autofillRule: '{{dataset.name}}',
+      ],
+      json: '{"autofillRule":"{{dataset.name}}"}'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testEvalVerbatimFilterReuse() {
+    def config = [
+      config: [
+        autofillRule: '{% verbatim %}{{dataset.name}}{% endverbatim %}',
+      ],
+      json: '{{ config | json }}',
+      reuse: '{{ json }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      config: [
+        autofillRule: '{{dataset.name}}',
+      ],
+      json: '{"autofillRule":"{{dataset.name}}"}',
+      reuse: '{"autofillRule":"{{dataset.name}}"}'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
   void testEvalConfig() {
     def config = [
       name: 'World',

--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
@@ -26,6 +26,8 @@ import to.wetransform.gradle.swarm.config.ConfigEvaluator;
 
 import static org.junit.Assert.*
 
+import java.lang.reflect.UndeclaredThrowableException
+
 import org.junit.After
 
 /**
@@ -68,6 +70,17 @@ abstract class ConfigEvaluatorTest<T extends ConfigEvaluator> {
     assert evaluated == expected
   }
 
+  @Test(expected = UndeclaredThrowableException) // wrapped AttributeNotFoundException
+  void testEvalConfigMissing() {
+    def config = [
+      hello: 'Hello {{ name }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    evaluated.hello
+  }
+
   @Test
   void testEvalConfigNested() {
     def config = [
@@ -91,6 +104,44 @@ abstract class ConfigEvaluatorTest<T extends ConfigEvaluator> {
       ]
 
     assert evaluated == expected
+  }
+
+  @Test(expected = UndeclaredThrowableException) // wrapped AttributeNotFoundException
+  void testEvalConfigNestedMissing() {
+    def config = [
+      name: 'World',
+      letter: 'To {{name}}: {{ down.phrase }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    evaluated.letter
+  }
+
+  @Test(expected = UndeclaredThrowableException) // wrapped AttributeNotFoundException
+  void testEvalConfigNestedMissing2() {
+    def config = [
+      name: 'World',
+      down: [:],
+      letter: 'To {{name}}: {{ down.phrase }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    evaluated.letter
+  }
+
+  @Test(expected = UndeclaredThrowableException) // wrapped AttributeNotFoundException
+  void testEvalConfigNestedMissing3() {
+    def config = [
+      name: 'World',
+      down: 'NotAnObect',
+      letter: 'To {{name}}: {{ down.phrase }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    evaluated.letter
   }
 
   @Test
@@ -192,7 +243,6 @@ abstract class ConfigEvaluatorTest<T extends ConfigEvaluator> {
     assert evaluated == expected
   }
 
-  @Ignore
   @Test
   void testEvalConfigIfString() {
     def config = [

--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
@@ -70,6 +70,54 @@ abstract class ConfigEvaluatorTest<T extends ConfigEvaluator> {
     assert evaluated == expected
   }
 
+  @Test
+  void testEvalConfigList() {
+    def config = [
+      name: 'World',
+      list: [
+        'Hello {{ name }}',
+        'Bye {{ name }}',
+        '{{ name }}?'
+        ]
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      name: 'World',
+      list: [
+        'Hello World',
+        'Bye World',
+        'World?'
+        ]
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testEvalConfigListRelative() {
+    def config = [
+      list: [
+        [name: 'Peter', text: 'Hello {{ name }}'],
+        [name: 'Tom', text: 'Hello {{ name }}!'],
+        [name: 'Sven', text: '{{ name }}?']
+        ]
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      list: [
+        [name: 'Peter', text: 'Hello Peter'],
+        [name: 'Tom', text: 'Hello Tom!'],
+        [name: 'Sven', text: 'Sven?']
+        ]
+      ]
+
+    assert evaluated == expected
+  }
+
   @Test(expected = UndeclaredThrowableException) // wrapped AttributeNotFoundException
   void testEvalConfigMissing() {
     def config = [

--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/ConfigEvaluatorTest.groovy
@@ -218,6 +218,60 @@ abstract class ConfigEvaluatorTest<T extends ConfigEvaluator> {
   }
 
   @Test
+  void testEvalConfigRootBeforeRelative() {
+    // resolving via root takes precedence over resolving locally/relative
+
+    def config = [
+      name: 'World',
+      down: [
+          name: 'Pete',
+          hello: 'Hello {{ name }}'
+        ],
+      letter: 'To {{name}}: {{ down.hello }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      name: 'World',
+      down: [
+          name: 'Pete',
+          hello: 'Hello World'
+        ],
+      letter: 'To World: Hello World'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testEvalConfigExplicitRelative() {
+    // resolving locally/relative can be forced with the special underscore key
+
+    def config = [
+      name: 'World',
+      down: [
+          name: 'Pete',
+          hello: 'Hello {{ _.name }}'
+        ],
+      letter: 'To {{name}}: {{ down.hello }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      name: 'World',
+      down: [
+          name: 'Pete',
+          hello: 'Hello Pete'
+        ],
+      letter: 'To World: Hello Pete'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
   void testEvalConfigNumber() {
     def config = [
       number: 1,

--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluatorTest.groovy
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2021 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.config.pebble
+
+import org.junit.Test
+
+/**
+ * Test for PebbleCachingEvaluator.
+ *
+ * @author Simon Templer
+ */
+class PebbleCachingEvaluatorTest extends ConfigEvaluatorTest<PebbleCachingEvaluator> {
+
+  @Override
+  protected PebbleCachingEvaluator createEvaluator() {
+    return new PebbleCachingEvaluator()
+  }
+
+  @Test
+  void testValueNested() {
+    def config = [
+      object: [name: 'Object1'],
+      value: 'Hallo {{ object.name }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      object: [name: 'Object1'],
+      value: 'Hallo Object1'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test(expected = StackOverflowError) //XXX can we improve this, e.g. detect loops and/or provide useful information to the user?
+  void testValueLoop() {
+    def config = [
+      foo: '{{ bar }}',
+      bar: '{{ foo }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    evaluated.bar
+  }
+
+  @Test
+  void testValueNested2() {
+    def config = [
+      object: [name: 'Object{{ object.num }}', num: 1],
+      value: 'Hallo {{ object.name }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      object: [name: 'Object1', num: 1],
+      value: 'Hallo Object1'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testValueNested2Order() {
+    def config = [
+      value: 'Hallo {{ object.name }}',
+      object: [name: 'Object{{ object.num }}', num: 1]
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      object: [name: 'Object1', num: 1],
+      value: 'Hallo Object1'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testDependenciesValueNested3() {
+    def config = [
+      object: [
+        properties: [
+          name: 'Object{{ object.properties.num }}',
+          num: 1
+        ]
+      ],
+      value: 'Hallo {{ object.properties.name }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    // check value directly to rule out any effect in evaluation order
+    assert evaluated.value == 'Hallo Object1'
+
+    def expected = [
+      object: [
+        properties: [
+          name: 'Object1',
+          num: 1
+        ]
+      ],
+      value: 'Hallo Object1'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testDependenciesValueMapAccessor() {
+    def config = [
+      object: [
+        properties: [
+          name: 'Object{{ object.properties.num }}',
+          num: 1
+        ]
+      ],
+      value: 'Hallo {{ object[\'properties\'].name }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      object: [
+        properties: [
+          name: 'Object1',
+          num: 1
+        ]
+      ],
+      value: 'Hallo Object1'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testValueDependent() {
+    def config = [
+      variable: 'bar',
+      object: [
+        foo: [name: 'Foo'],
+        bar: [name: 'Bar']
+        ],
+      value: 'Hallo {{ object[variable].name }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      variable: 'bar',
+      object: [
+        foo: [name: 'Foo'],
+        bar: [name: 'Bar']
+        ],
+      value: 'Hallo Bar'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testValueDependent2() {
+    def config = [
+      variable: [sub: 'bar'],
+      object: [
+        foo: [name: 'Foo'],
+        bar: [name: 'Bar']
+        ],
+      value: 'Hallo {{ object[variable.sub].name }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      variable: [sub: 'bar'],
+      object: [
+        foo: [name: 'Foo'],
+        bar: [name: 'Bar']
+        ],
+      value: 'Hallo Bar'
+      ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testDependenciesValueComplex() {
+    def config = [
+      latest_config_version: 10,
+      condition: true, // as string?
+      config_breaking_version: '{{ latest_config_version }}',
+      value: '{{ (toInt(config_breaking_version) < 4) and (not condition) }}'
+      ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      latest_config_version: 10,
+      condition: true, // as string?
+      config_breaking_version: '10',
+      value: false
+      ]
+
+    assert evaluated == expected
+  }
+
+}

--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleEvaluatorTest.groovy
@@ -18,6 +18,7 @@ package to.wetransform.gradle.swarm.config.pebble
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore
 import org.junit.Test
 
 import to.wetransform.gradle.swarm.config.ConfigEvaluator;
@@ -29,9 +30,9 @@ import static org.junit.Assert.*
  *
  * @author Simon Templer
  */
+@Ignore
 class PebbleEvaluatorTest extends ConfigEvaluatorTest<PebbleEvaluator> {
 
-  @Override
   protected PebbleEvaluator createEvaluator() {
     new PebbleEvaluator()
   }
@@ -49,6 +50,78 @@ class PebbleEvaluatorTest extends ConfigEvaluatorTest<PebbleEvaluator> {
   @Test
   void testIsDynamicValuePartial() {
     assertTrue(eval.isDynamicValue("Hallo {{ name }}"))
+  }
+
+  @Test
+  void testIsDynamicValueNested() {
+    assertTrue(eval.isDynamicValue("Hallo {{ object.name }}"))
+  }
+
+  @Test
+  void testDependenciesValueStatic() {
+    def deps = eval.getDependencies("Hallo Welt")
+    assert deps.isEmpty()
+  }
+
+  @Test
+  void testDependenciesFullExpr() {
+    def deps = eval.getDependencies("{{ some_var }}")
+    assert deps.size() == 1
+    assert deps.iterator().next() == ['some_var']
+  }
+
+  @Test
+  void testDependenciesValuePartial() {
+    def deps = eval.getDependencies("Hallo {{ name }}")
+    assert deps.size() == 1
+    assert deps.iterator().next() == ['name']
+  }
+
+  @Test
+  void testDependenciesValueNested() {
+    def deps = eval.getDependencies("Hallo {{ object.name }}")
+    assert deps.size() == 1
+    assert deps.iterator().next() == ['object', 'name']
+  }
+
+  @Test
+  void testDependenciesValueNested2() {
+    def deps = eval.getDependencies("Hallo {{ object.property.name }}")
+    assert deps.size() == 1
+    assert deps.iterator().next() == ['object', 'property', 'name']
+  }
+
+  @Test
+  void testDependenciesValueMapAccessor() {
+    def deps = eval.getDependencies("Hallo {{ object['property'].name }}")
+    assert deps.size() == 1
+    assert deps.iterator().next() == ['object', 'property', 'name']
+  }
+
+  @Ignore
+  @Test
+  void testDependenciesValueDependent() {
+    def deps = eval.getDependencies("Hallo {{ object[variable].name }}")
+    assert deps.size() == 2
+    assert deps.contains(['variable'])
+    assert deps.contains(['object']) //XXX what to expect here? without a value for "variable" we can't get anything meaning full here?
+  }
+
+  @Ignore
+  @Test
+  void testDependenciesValueDependent2() {
+    def deps = eval.getDependencies("Hallo {{ object[variable.sub].name }}")
+    assert deps.size() == 2
+    assert deps.contains(['variable', 'sub'])
+    assert deps.contains(['object']) //XXX what to expect here? without a value for "variable" we can't get anything meaning full here?
+  }
+
+  @Test
+  void testDependenciesValueComplex() {
+    def deps = eval.getDependencies("{{ (toInt(config_breaking_version) < 4) and (not service_publisher.map_proxy.use_s3_cache) }}")
+    assert deps.size() == 2
+    assert deps.contains(['config_breaking_version'])
+    assert deps.contains(['service_publisher', 'map_proxy', 'use_s3_cache'])
   }
 
 }


### PR DESCRIPTION
- assure correct evaluation order and avoid too early evaluation of some expressions
- support for lazy evaluation (of only the variables that are actually
  used in a setup

Also added some experimental logic on determining variable dependencies
for a Pebble expression which was intended to be used for the evaluation
improvements, but was not needed after all.

ING-2940

Also:
- feat: add hook for adapting setup configurations (to fix issue with local overrides not working for image builds)
- feat: add tasks for exporting setup configuration (for debugging purposes)
- feat: support explicit access to local/relative configuration (to better support resolving relative configuration variables)