### PR TITLE
feat: add filter that allows expanding objects

### DIFF
--- a/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/ExpandFilter.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/ExpandFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 wetransform GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package to.wetransform.gradle.swarm.actions.assemble.template;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.extension.Filter;
+import com.mitchellbosecke.pebble.template.EvaluationContext;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+
+import groovy.json.JsonOutput;
+import groovy.json.JsonSlurper;
+
+/**
+ * Filter that uses Json encoding to facilitate copying configuration into types that are not only string or boolean.
+ * It uses a magix prefix and suffix for identification.
+ *
+ * Note that recreating objects from the filter result is only possible if the expanded object is the only content of the string.
+ *
+ * @author Simon Templer
+ */
+public class ExpandFilter implements Filter {
+
+  public static final String PREFIX = "___GSC_EXPAND(";
+  public static final String SUFFIX = ")___EXPAND_GSC";
+
+  public static Object expandString(String text) {
+    if (text != null && text.startsWith(PREFIX) && text.endsWith(SUFFIX)) {
+      String core = text.substring(PREFIX.length(), text.length() - SUFFIX.length());
+      try {
+        return new JsonSlurper().parseText(core);
+      } catch (Exception e) {
+        throw new RuntimeException("Unable to parse Json expected from expand filter", e);
+      }
+    }
+
+    return text;
+  }
+
+  @Override
+  public List<String> getArgumentNames() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Object apply(Object input, Map<String, Object> args, PebbleTemplate self, EvaluationContext context,
+      int lineNumber) throws PebbleException {
+    if (input instanceof ContextWrapper) {
+      input = ((ContextWrapper) input).getInternalMap();
+    }
+
+    StringBuilder result = new StringBuilder();
+    result.append(PREFIX);
+    result.append(JsonOutput.toJson(input));
+    result.append(SUFFIX);
+
+    return result.toString();
+  }
+
+}

--- a/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/SwarmComposerExtension.java
+++ b/src/main/groovy/to/wetransform/gradle/swarm/actions/assemble/template/SwarmComposerExtension.java
@@ -54,6 +54,7 @@ public class SwarmComposerExtension extends AbstractExtension {
     filters.put("indent", new IndentLineFilter());
     filters.put("yaml", new YamlFilter());
     filters.put("json", new JsonFilter());
+    filters.put("expand", new ExpandFilter());
     filters.put("prettyJson", new PrettyJsonFilter());
     filters.put("ifNull", new IfNullFilter());
     filters.put("orError", new OrErrorFilter());

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluator.groovy
@@ -43,6 +43,7 @@ import com.mitchellbosecke.pebble.template.PebbleTemplate
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import to.wetransform.gradle.swarm.actions.assemble.template.ContextWrapper;
+import to.wetransform.gradle.swarm.actions.assemble.template.ExpandFilter
 import to.wetransform.gradle.swarm.actions.assemble.template.LazyContextWrapper
 import to.wetransform.gradle.swarm.actions.assemble.template.SwarmComposerExtension
 import to.wetransform.gradle.swarm.config.ConfigEvaluator
@@ -133,7 +134,7 @@ public class PebbleCachingEvaluator extends AbstractPebbleEvaluator {
         false
       }
       else {
-        result
+        ExpandFilter.expandString(result)
       }
     }
 

--- a/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleEvaluator.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleEvaluator.groovy
@@ -36,6 +36,7 @@ import com.mitchellbosecke.pebble.parser.ParserImpl
 import com.mitchellbosecke.pebble.template.PebbleTemplate
 
 import to.wetransform.gradle.swarm.actions.assemble.template.ContextWrapper;
+import to.wetransform.gradle.swarm.actions.assemble.template.ExpandFilter
 import to.wetransform.gradle.swarm.actions.assemble.template.SwarmComposerExtension
 import to.wetransform.gradle.swarm.config.ConfigEvaluator
 import to.wetransform.gradle.swarm.config.ConfigHelper
@@ -173,7 +174,7 @@ class PebbleEvaluator extends AbstractPebbleEvaluator {
       false
     }
     else {
-      result
+      ExpandFilter.expandString(result)
     }
   }
 

--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluatorTest.groovy
@@ -221,4 +221,131 @@ class PebbleCachingEvaluatorTest extends ConfigEvaluatorTest<PebbleCachingEvalua
     assert evaluated == expected
   }
 
+  @Test
+  void testExpandList() {
+    def config = [
+      name: 'Jim',
+      list: ['Hello {{ name }}', 'Bye {{ name }}'],
+      copy: '{{ list | expand }}'
+    ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      name: 'Jim',
+      list: ['Hello Jim', 'Bye Jim'],
+      copy: ['Hello Jim', 'Bye Jim']
+    ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testExpandNumber() {
+    def config = [
+      number: 12,
+      copy: '{{ number | expand }}'
+    ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      number: 12,
+      copy: 12
+    ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testNotExpandNumber() {
+    def config = [
+      number: 12,
+      copy: '{{ number }}'
+    ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      number: 12,
+      copy: '12'
+    ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testExpandMap() {
+    def config = [
+      name: 'Jim',
+      map: [
+        name: '{{ name }}',
+        hello: 'Hello {{ name }}',
+        there: 'Tom',
+        helloThere: 'Hello {{ _.there }}'
+      ],
+      copy: '{{ map | expand }}'
+    ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      name: 'Jim',
+      map: [
+        name: 'Jim',
+        hello: 'Hello Jim',
+        there: 'Tom',
+        helloThere: 'Hello Tom'
+      ],
+      copy: [
+        name: 'Jim',
+        hello: 'Hello Jim',
+        there: 'Tom',
+        helloThere: 'Hello Tom'
+      ]
+    ]
+
+    assert evaluated == expected
+  }
+
+  @Test
+  void testExpandMix() {
+    def config = [
+      name: 'Jim',
+      map: [
+        hello: 'Hello {{ name }}',
+        list: ['{{ map.hello }}', 'Bye {{ name }}'],
+        more: [
+          foo: 'bar',
+          story: '{{ name }} went to a bar.'
+        ]
+      ],
+      copy: '{{ map | expand }}'
+    ]
+
+    def evaluated = eval.evaluate(config)
+
+    def expected = [
+      name: 'Jim',
+      map: [
+        hello: 'Hello Jim',
+        list: ['Hello Jim', 'Bye Jim'],
+        more: [
+          foo: 'bar',
+          story: 'Jim went to a bar.'
+        ]
+      ],
+      copy: [
+        hello: 'Hello Jim',
+        list: ['Hello Jim', 'Bye Jim'],
+        more: [
+          foo: 'bar',
+          story: 'Jim went to a bar.'
+        ]
+      ]
+    ]
+
+    assert evaluated == expected
+  }
+
 }


### PR DESCRIPTION
Previously Pebble evaluators for configuration would only allow strings
and booleans as results.
With the new `expand` filter it is possible to also yield other kinds of
objects, given that the result of the expand filter is the only thing in
the string.