### PR TITLE
revert: fix: fix ConcurrentModificationException on Java 9+

### DIFF
--- a/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluatorTest.groovy
+++ b/src/test/groovy/to/wetransform/gradle/swarm/config/pebble/PebbleCachingEvaluatorTest.groovy
@@ -16,7 +16,6 @@
 
 package to.wetransform.gradle.swarm.config.pebble
 
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -48,7 +47,7 @@ class PebbleCachingEvaluatorTest extends ConfigEvaluatorTest<PebbleCachingEvalua
     assert evaluated == expected
   }
 
-  @Test(expected = IllegalStateException)
+  @Test(expected = StackOverflowError) //XXX can we improve this, e.g. detect loops and/or provide useful information to the user?
   void testValueLoop() {
     def config = [
       foo: '{{ bar }}',


### PR DESCRIPTION
Reverts wetransform-os/gradle-swarm-composer#30

It seems that there can be cases where this leads to the evaluation not terminating, though we don't have a reproduction case as test case at the moment. Workaround is to for now stay with using Java 8.

