### PR TITLE
perf: cache setting templates

### DIFF
--- a/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerPlugin.groovy
+++ b/src/main/groovy/to/wetransform/gradle/swarm/SwarmComposerPlugin.groovy
@@ -49,6 +49,8 @@ class SwarmComposerPlugin implements Plugin<Project> {
 
   private final def groovyEngine = new groovy.text.SimpleTemplateEngine()
 
+  private final Map<String, groovy.text.Template> cachedTemplates = [:]
+
   void apply(Project project) {
     // register extension
     project.extensions.create('composer', SwarmComposerExtension, project)
@@ -993,7 +995,7 @@ $run"""
    * @return the evaluated setting
    */
   private String evaluateSetting(String setting, Map binding) {
-    def template = groovyEngine.createTemplate(setting).make(binding)
+    def template = cachedTemplates.computeIfAbsent(setting, s -> { groovyEngine.createTemplate(s) }).make(binding)
     try {
       template.toString()
     } catch (Exception e) {


### PR DESCRIPTION
...for the same setting, since parsing the templates is quite expensive. With this change in an example project ~20s build time could be saved for a single build.